### PR TITLE
feat: raw SQL CRUD for tasks with JWT double-check

### DIFF
--- a/Core/app/auth_utils.py
+++ b/Core/app/auth_utils.py
@@ -2,8 +2,8 @@ import jwt
 import bcrypt
 from datetime import datetime, timedelta, timezone
 from app.config import settings
-from fastapi import Security, HTTPException, status
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi import HTTPException, status
+
 
 SECRET_KEY = settings.JWT_SECRET_KEY
 ALGORITHM = settings.JWT_ALGORITHM
@@ -43,7 +43,7 @@ async def get_current_user_double_check(db, credentials) -> str:
     
     # ЧЕК 2: Быстрый запрос в MySQL
     async with db.cursor() as cursor:
-        await cursor.execute("SELECT username FROM users WHERE username = %s", (username,))
+        await cursor.execute("SELECT user_id, username FROM users WHERE username = %s", (username,))
         user_exists = await cursor.fetchone()
 
     if not user_exists:
@@ -52,4 +52,4 @@ async def get_current_user_double_check(db, credentials) -> str:
             detail="Доступ запрещён: пользователь удалён или заблокирован"
         )
     
-    return username
+    return user_exists[0], user_exists[1]

--- a/Core/app/routers/tasks.py
+++ b/Core/app/routers/tasks.py
@@ -1,42 +1,156 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPBearer
+from app.database import get_db
 from app.schemas.tasks import TaskCreate, TaskUpdate
+from app.auth_utils import get_current_user_double_check
 
 router = APIRouter(prefix="/api/tasks", tags=["Tasks"])
+security_scheme = HTTPBearer()
 
 
 # [C]REATE
-@router.post("")
-def create_task(task_data: TaskCreate):
-    # TODO: Тут будет SQL: INSERT INTO tasks (title, description) VALUES (...) и прочий ужас
-    return {
-        "status": "success",
-        "message": f"Задача '{task_data.title}' успешно создана в системе Murkoff!",
-        "id": 101  # Пока что фейковый ID, нужна база данных
-    }
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_task(
+    task_data: TaskCreate,
+    db = Depends(get_db),
+    token = Depends(security_scheme)
+) -> dict:
+    try:
+
+        current_user_id, current_username = await get_current_user_double_check(db=db, credentials=token)
+
+        async with db.cursor() as cursor:
+            insert_query = "INSERT INTO tasks (user_id, task_number, description, deadline, priority, status) VALUES (%s, %s, %s, %s, %s, %s)"
+            await cursor.execute(insert_query, (
+                current_user_id, 
+                task_data.task_number, 
+                task_data.description, 
+                task_data.deadline, 
+                task_data.priority, 
+                task_data.status
+            ))
+        
+        return {
+            "status": "success",
+            "message": f"Задача №'{task_data.task_number}' успешно создана сотрудником {current_username}!"
+        }
+    
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Ошибка базы данных при создании задачи: {str(e)}"
+        )
 
 # [R]EAD
 @router.get("")
-def read_tasks():
-    # TODO: Тут будет SQL: SELECT * FROM tasks;
-    return [
-        {"id": 101, "title": "Проверить статус Реагентов с последнего испытания", "status": "new", "description": "Срочно"},
-        {"id": 102, "title": "Эксперимент над новым Экс-Попом", "status": "in_progress", "description": "Секретно"}
-    ]
+async def read_tasks(
+    db = Depends(get_db),
+    token = Depends(security_scheme)
+) -> dict:
+    try:
 
+        current_user_id, current_username = await get_current_user_double_check(db=db, credentials=token)
+
+        async with db.cursor() as cursor:
+            await cursor.execute("SELECT task_id, user_id, task_number, description, deadline, priority, status, created_at, updated_at FROM tasks WHERE user_id = %s", (current_user_id,))
+            raw_tasks = await cursor.fetchall()
+
+        tasks_list = []
+        for row in raw_tasks:
+            tasks_list.append({
+                "task_id": row[0],
+                "user_id": row[1],
+                "task_number": row[2],
+                "description": row[3],
+                "deadline": row[4].isoformat() if row[4] else None,   # Безопасный перевод в str
+                "priority": row[5],
+                "status": row[6],
+                "created_at": row[7].isoformat() if row[7] else None, # Безопасный перевод в str
+                "updated_at": row[8].isoformat() if row[8] else None  # Безопасный перевод в str
+            })
+
+        return {
+            "status": "success",
+            "requested_by": current_username,
+            "tasks": tasks_list
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Ошибка базы данных при получении списка задач: {str(e)}"
+        )
+    
 # [U]PDATE
 @router.put("/{task_id}")
-def update_task(task_id: int, task_data: TaskUpdate):
-    # TODO: Тут будет SQL: UPDATE tasks SET status = %s WHERE id = %s;
-    return {
-        "status": "success",
-        "message": f"Статус задачи №{task_id} успешно изменён на '{task_data.status}'"
-    }
+async def update_task(
+    task_id: int,
+    task_data: TaskUpdate,
+    db = Depends(get_db),
+    token = Depends(security_scheme)
+) -> dict:
+    try:
+
+        current_user_id, current_username = await get_current_user_double_check(db=db, credentials=token)
+
+        async with db.cursor() as cursor:
+            await cursor.execute("SELECT task_id FROM tasks WHERE task_id = %s AND user_id = %s", (task_id, current_user_id))
+            if not await cursor.fetchone():
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Задача не найдена или у вас нет прав на её изменение"
+                )
+
+            update_query = "UPDATE tasks SET task_number = %s WHERE task_id = %s"
+            await cursor.execute(update_query, (task_data.task_number, task_id))
+
+        return {
+            "status": "success",
+            "message": f"Номер задачи ID {task_id} успешно изменён сотрудником {current_username}."
+        }
+    
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Ошибка базы данных при обновлении задачи: {str(e)}"
+        )
 
 # [D]ELETE
 @router.delete("/{task_id}")
-def delete_task(task_id: int):
-    # TODO: Тут будет SQL: DELETE FROM tasks WHERE id = %s;
-    return {
-        "status": "success",
-        "message": f"Задача №{task_id} удалена из архива"
-    }
+async def delete_task(
+    task_id: int,
+    db = Depends(get_db),
+    token = Depends(security_scheme)
+) -> dict:
+    try:
+
+        current_user_id, current_username = await get_current_user_double_check(db=db, credentials=token)
+
+        async with db.cursor() as cursor:
+            await cursor.execute("SELECT task_id FROM tasks WHERE task_id = %s AND user_id = %s", (task_id, current_user_id))
+            if not await cursor.fetchone():
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Задача не найдена или у вас нет прав на её удаление"
+                )
+            
+            await cursor.execute("DELETE FROM tasks WHERE task_id = %s", (task_id,))
+
+        return {
+            "status": "success",
+            "message": f"Задача №{task_id} безвозвратно удалена из архива Murkoff сотрудником {current_username}."
+        }
+    
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Ошибка базы данных при удалении задачи: {str(e)}"
+        )

--- a/Core/app/schemas/tasks.py
+++ b/Core/app/schemas/tasks.py
@@ -1,10 +1,20 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from datetime import datetime
+from typing import Optional
 
-# Схема для создания задачи
+# Схема для создания задачи [POST]
 class TaskCreate(BaseModel):
-    title: str
-    description: str | None = None
+    task_number: str = Field(..., max_length=20, description="Уникальный номер задачи")
+    description: Optional[str] = Field(None, description="Полное описание задачи")
+    deadline: Optional[datetime] = Field(None, description="Дедлайн выполнения")
+    priority: Optional[str] = Field("medium", max_length=20, description="Приоритет")
+    status: Optional[str] = Field("new", max_length=20, description="Статус задачи (new, in_progress, done)")
 
-# Схема для обновления статуса задачи
+# Схема для обновления статуса задачи [PUT]
 class TaskUpdate(BaseModel):
-    status: str
+    task_number: Optional[str] = Field(None, max_length=20)
+    description: Optional[str] = Field(None)
+    deadline: Optional[datetime] = Field(None)
+    priority: Optional[str] = Field(None, max_length=20)
+    status: Optional[str] = Field(None, max_length=20)
+    


### PR DESCRIPTION
- Implemented a full isolated CRUD for tasks (tasks.py) using clean async raw SQL.
- Added Pydantic request validation and consistent error handling.
- Secured all task routes with the DB-backed JWT "double-check" module.
